### PR TITLE
add default config properties for type-list view options

### DIFF
--- a/src/main/resources/default/properties.json
+++ b/src/main/resources/default/properties.json
@@ -173,5 +173,38 @@
         }
       ]
     }
+  },
+  {
+    "id": "configGraphHomeLayout",
+    "properties": {
+      "prefLabel": [
+        {
+          "lang": "en",
+          "value": "config: graph home default"
+        }
+      ]
+    }
+  },
+  {
+    "id": "configBrowsingRootNode",
+    "properties": {
+      "prefLabel": [
+        {
+          "lang": "en",
+          "value": "config: browsing root node"
+        }
+      ]
+    }
+  },
+  {
+    "id": "configHideFromTypeView",
+    "properties": {
+      "prefLabel": [
+        {
+          "lang": "en",
+          "value": "config: hide from type view"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
This change is a prerequesite for the "list view with configurations" pull request in the **termed-ui** project: https://github.com/THLfi/termed-ui/pull/5

The change adds the required configuration properties to the list of default properties.