### PR TITLE
Add support for generating URIs that have namespace specific numbering.

### DIFF
--- a/src/main/java/fi/thl/termed/service/node/internal/DocumentToNode.java
+++ b/src/main/java/fi/thl/termed/service/node/internal/DocumentToNode.java
@@ -1,5 +1,7 @@
 package fi.thl.termed.service.node.internal;
 
+import static com.google.common.base.Strings.emptyToNull;
+
 import com.google.common.collect.ImmutableMultimap;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
@@ -67,10 +69,10 @@ public class DocumentToNode implements Function<Document, Node> {
           number = Long.valueOf(fieldValue);
           continue;
         case "uri":
-          uri = fieldValue;
+          uri = emptyToNull(fieldValue);
           continue;
         case "code":
-          code = fieldValue;
+          code = emptyToNull(fieldValue);
           continue;
         case "createdBy":
           createdBy = fieldValue;

--- a/src/main/java/fi/thl/termed/service/node/internal/JdbcNodeNamespaceSequenceDao.java
+++ b/src/main/java/fi/thl/termed/service/node/internal/JdbcNodeNamespaceSequenceDao.java
@@ -1,0 +1,100 @@
+package fi.thl.termed.service.node.internal;
+
+import fi.thl.termed.domain.GraphId;
+import fi.thl.termed.util.UUIDs;
+import fi.thl.termed.util.collect.Tuple;
+import fi.thl.termed.util.collect.Tuple2;
+import fi.thl.termed.util.dao.AbstractJdbcDao;
+import fi.thl.termed.util.query.SqlSpecification;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.RowMapper;
+
+public class JdbcNodeNamespaceSequenceDao extends AbstractJdbcDao<Tuple2<GraphId, String>, Long> {
+
+  public JdbcNodeNamespaceSequenceDao(DataSource dataSource) {
+    super(dataSource);
+  }
+
+  @Override
+  public void insert(Tuple2<GraphId, String> graphIdNamespace, Long value) {
+    GraphId graphId = graphIdNamespace._1;
+    String namespace = graphIdNamespace._2;
+
+    jdbcTemplate.update(
+        "insert into node_namespace_sequence (graph_id, namespace, value) values (?, ?, ?)",
+        graphId.getId(),
+        namespace,
+        value);
+  }
+
+  @Override
+  public void update(Tuple2<GraphId, String> graphIdNamespace, Long value) {
+    GraphId graphId = graphIdNamespace._1;
+    String namespace = graphIdNamespace._2;
+
+    jdbcTemplate.update(
+        "update node_namespace_sequence set value = ? where graph_id = ? and namespace = ?",
+        value,
+        graphId.getId(),
+        namespace);
+  }
+
+  @Override
+  public void delete(Tuple2<GraphId, String> graphIdNamespace) {
+    GraphId graphId = graphIdNamespace._1;
+    String namespace = graphIdNamespace._2;
+
+    jdbcTemplate.update(
+        "delete from node_namespace_sequence where graph_id = ? and namespace = ?",
+        graphId.getId(),
+        namespace);
+  }
+
+  @Override
+  protected <E> Stream<E> get(SqlSpecification<Tuple2<GraphId, String>, Long> specification,
+      RowMapper<E> mapper) {
+    return jdbcTemplate.queryForStream(
+        String.format("select * from node_namespace_sequence where %s",
+            specification.sqlQueryTemplate()),
+        specification.sqlQueryParameters(), mapper);
+  }
+
+  @Override
+  public boolean exists(Tuple2<GraphId, String> graphIdNamespace) {
+    GraphId graphId = graphIdNamespace._1;
+    String namespace = graphIdNamespace._2;
+
+    return jdbcTemplate.queryForOptional(
+        "select count(*) from node_namespace_sequence where graph_id = ? and namespace = ?",
+        Long.class,
+        graphId.getId(),
+        namespace).orElseThrow(IllegalStateException::new) > 0;
+  }
+
+  @Override
+  protected <E> Optional<E> get(Tuple2<GraphId, String> graphIdNamespace, RowMapper<E> mapper) {
+    GraphId graphId = graphIdNamespace._1;
+    String namespace = graphIdNamespace._2;
+
+    return jdbcTemplate.queryForFirst(
+        "select * from node_namespace_sequence where graph_id = ? and namespace = ?",
+        mapper,
+        graphId.getId(),
+        namespace);
+  }
+
+  @Override
+  protected RowMapper<Tuple2<GraphId, String>> buildKeyMapper() {
+    return (rs, rowNum) -> Tuple.of(
+        GraphId.of(UUIDs.fromString(rs.getString("graph_id"))),
+        rs.getString("namespace"));
+  }
+
+  @Override
+  protected RowMapper<Long> buildValueMapper() {
+    return (rs, rowNum) -> rs.getLong("value");
+  }
+
+}

--- a/src/main/java/fi/thl/termed/util/collect/Tuple.java
+++ b/src/main/java/fi/thl/termed/util/collect/Tuple.java
@@ -1,10 +1,11 @@
 package fi.thl.termed.util.collect;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public interface Tuple {
+public interface Tuple extends Serializable {
 
   static <T1, T2> Stream<Tuple2<T1, T2>> entriesAsTuples(Map<T1, T2> map) {
     return map.entrySet().stream().map(Tuple::of);

--- a/src/main/java/fi/thl/termed/util/rdf/JenaUtils.java
+++ b/src/main/java/fi/thl/termed/util/rdf/JenaUtils.java
@@ -16,6 +16,13 @@ public final class JenaUtils {
     return model;
   }
 
+  public static Model fromRdfTtlString(String rdfXml) {
+    Reader stringReader = new StringReader(rdfXml);
+    Model model = ModelFactory.createDefaultModel();
+    model.read(stringReader, "", "TTL");
+    return model;
+  }
+
   public static String toRdfXmlString(Model model) {
     Writer stringWriter = new StringWriter();
     model.write(stringWriter, "RDF/XML");

--- a/src/main/resources/db/migration/common/V13__Add_node_namespace_sequence.sql
+++ b/src/main/resources/db/migration/common/V13__Add_node_namespace_sequence.sql
@@ -1,0 +1,9 @@
+
+CREATE TABLE node_namespace_sequence (
+  graph_id uuid,
+  namespace varchar(1000),
+  value bigint NOT NULL,
+  CONSTRAINT node_namespace_sequence_pkey PRIMARY KEY (graph_id, namespace),
+  CONSTRAINT node_namespace_sequence_graph_fkey FOREIGN KEY (graph_id)
+    REFERENCES graph(id) ON DELETE CASCADE
+);

--- a/src/test/java/fi/thl/termed/service/node/NodeUriSavingServiceIntegrationTest.java
+++ b/src/test/java/fi/thl/termed/service/node/NodeUriSavingServiceIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 class NodeUriSavingServiceIntegrationTest extends BaseNodeServiceIntegrationTest {
 
   @Test
-  void shouldGenerateUriUsingGivenNamespace() {
+  void shouldGenerateUriUsingGivenNamespaceAndCode() {
     NodeId nodeId0 = NodeId.random("Person", graphId);
     Node node0 = Node.builder()
         .id(nodeId0)
@@ -29,6 +29,55 @@ class NodeUriSavingServiceIntegrationTest extends BaseNodeServiceIntegrationTest
 
     assertEquals("http://example.org/example-code-0",
         nodeService.get(nodeId0, user)
+            .orElseThrow(AssertionError::new)
+            .getUri()
+            .orElseThrow(AssertionError::new));
+  }
+
+  @Test
+  void shouldGenerateUriUsingGivenNamespace() {
+    NodeId nodeId0 = NodeId.random("Person", graphId);
+    Node node0 = Node.builder()
+        .id(nodeId0)
+        .build();
+
+    assertFalse(nodeService.exists(nodeId0, user));
+
+    nodeService.save(node0, INSERT,
+        opts(false, "http://example.org/", true, true), user);
+
+    assertEquals("http://example.org/person-0",
+        nodeService.get(nodeId0, user)
+            .orElseThrow(AssertionError::new)
+            .getUri()
+            .orElseThrow(AssertionError::new));
+  }
+
+  @Test
+  void shouldGenerateUrisWithDifferentCountersForEachNamespace() {
+    NodeId nodeId0 = NodeId.random("Person", graphId);
+    Node node0 = Node.builder()
+        .id(nodeId0)
+        .build();
+    NodeId nodeId1 = NodeId.random("Person", graphId);
+    Node node1 = Node.builder()
+        .id(nodeId1)
+        .build();
+
+    assertFalse(nodeService.exists(nodeId0, user));
+
+    nodeService.save(node0, INSERT,
+        opts(false, "http://example.org/", true, true), user);
+    nodeService.save(node1, INSERT,
+        opts(false, "http://foobar.com/", true, true), user);
+
+    assertEquals("http://example.org/person-0",
+        nodeService.get(nodeId0, user)
+            .orElseThrow(AssertionError::new)
+            .getUri()
+            .orElseThrow(AssertionError::new));
+    assertEquals("http://foobar.com/person-0",
+        nodeService.get(nodeId1, user)
             .orElseThrow(AssertionError::new)
             .getUri()
             .orElseThrow(AssertionError::new));

--- a/src/test/java/fi/thl/termed/web/RdfExportIntegrationTest.java
+++ b/src/test/java/fi/thl/termed/web/RdfExportIntegrationTest.java
@@ -1,0 +1,95 @@
+package fi.thl.termed.web;
+
+import static fi.thl.termed.util.io.ResourceUtils.resourceToString;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import fi.thl.termed.domain.DefaultUris;
+import fi.thl.termed.domain.Node;
+import fi.thl.termed.domain.TypeId;
+import fi.thl.termed.util.rdf.JenaUtils;
+import fi.thl.termed.util.rdf.RdfMediaTypes;
+import java.util.Arrays;
+import java.util.UUID;
+import org.apache.http.HttpStatus;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+
+class RdfExportIntegrationTest extends BaseApiIntegrationTest {
+
+  @Value("${fi.thl.termed.defaultNamespace:}")
+  private String defaultNamespace;
+
+  @Test
+  void shouldExportRdfForNodesWithoutGivenUris() {
+    UUID graphId = UUID.randomUUID();
+
+    // save graph and types
+    given(adminAuthorizedJsonSaveRequest)
+        .body(resourceToString("examples/termed/animals-graph.json"))
+        .put("/api/graphs/" + graphId + "?mode=insert");
+    given(adminAuthorizedJsonSaveRequest)
+        .body(resourceToString("examples/termed/animals-types.json"))
+        .post("/api/graphs/" + graphId + "/types?batch=true");
+
+    Node animalNode = Node.builder()
+        .random(TypeId.of("Concept", graphId))
+        .addProperty("prefLabel", "Animal")
+        .build();
+
+    Node dogNode = Node.builder()
+        .random(TypeId.of("Concept", graphId))
+        .addProperty("prefLabel", "Dog")
+        .addReference("broader", animalNode.identifier())
+        .build();
+
+    // save a few nodes
+    given(adminAuthorizedJsonSaveRequest)
+        .body(Arrays.asList(animalNode, dogNode))
+        .post("/api/graphs/" + graphId + "/nodes?batch=true&generateCodes=false&generateUris=false")
+        .then()
+        .statusCode(HttpStatus.SC_NO_CONTENT);
+
+    // verify that nodes got saved
+    given(adminAuthorizedJsonGetRequest)
+        .get("/api/graphs/" + graphId + "/node-count")
+        .then()
+        .body(equalTo("2"));
+
+    String rdfResponse = given(adminAuthorizedRequest)
+        .accept(RdfMediaTypes.TURTLE_VALUE)
+        .get("/api/graphs/" + graphId + "/nodes")
+        .thenReturn()
+        .getBody()
+        .prettyPrint();
+
+    Model rdfModel = JenaUtils.fromRdfTtlString(rdfResponse);
+
+    assertTrue(rdfModel.contains(
+        ResourceFactory.createResource(
+            DefaultUris.uri(defaultNamespace, animalNode.identifier())),
+        SKOS.prefLabel,
+        "Animal"));
+    assertTrue(rdfModel.contains(
+        ResourceFactory.createResource(
+            DefaultUris.uri(defaultNamespace, dogNode.identifier())),
+        SKOS.prefLabel,
+        "Dog"));
+    assertTrue(rdfModel.contains(
+        ResourceFactory.createResource(
+            DefaultUris.uri(defaultNamespace, dogNode.identifier())),
+        SKOS.broader,
+        ResourceFactory.createResource(
+            DefaultUris.uri(defaultNamespace, animalNode.identifier()))));
+
+    // clean up
+    given(adminAuthorizedRequest).delete("/api/graphs/" + graphId + "/nodes");
+    given(adminAuthorizedRequest).delete("/api/graphs/" + graphId + "/types");
+    given(adminAuthorizedRequest).delete("/api/graphs/" + graphId);
+  }
+
+}

--- a/src/test/java/fi/thl/termed/web/docs/NodeApiDocumentingIntegrationTest.java
+++ b/src/test/java/fi/thl/termed/web/docs/NodeApiDocumentingIntegrationTest.java
@@ -152,9 +152,14 @@ class NodeApiDocumentingIntegrationTest extends BaseNodeApiDocumentingIntegratio
                     .description("Optional parameter to define whether missing URIs are "
                         + "automatically generated. Default value is `true`."),
                 parameterWithName("uriNamespace").optional()
-                    .description("Optional parameter to give URI namespace for generated URIs. "
-                        + "By default Graph URI is used, and if not present, configuration property "
-                        + "`fi.thl.termed.defaultNamespace` is used."),
+                    .description("Optional parameter to give URI namespace for generated URIs.\n\n"
+                        + "Note that URI local names are generated differently when URI namespace "
+                        + "is given (and node has no `code` value to be used for local name): "
+                        + "local name number part is generated from a sequence specific to given "
+                        + "namespace. Numbering applies to URI only, node will still have `number` "
+                        + "and `code` fields generated as usual.\n\n"
+                        + "Default value is empty and Graph URI is used as namespace. If Graph has "
+                        + "no URI, configuration property `fi.thl.termed.defaultNamespace` is used."),
                 parameterWithName("generateCodes").optional()
                     .description("Optional parameter to define whether missing codes are "
                         + "automatically generated. Default value is `true`.")),


### PR DESCRIPTION
When uriNamespace request parameter is given in node save request (and node does not contain code), URI is generated differently than usual. URI local name number is loaded from namespace specific sequence. The idea is that same graph type can contain nodes with different URI namespaces each having its own numbering. URI namespace specific local name numbering does not affect actual node numbering or node code numbering.